### PR TITLE
added the invert_commands option

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg?style=for-the-badge)](https://github.com/custom-components/hacs)
 
-This card allows to open, close or set a blind to the position you want. The Color of the blind can also be defined. This is a fork of the Shutter Card by Deejayfool
+This card allows to open, close or set a blind to the position you want. The Color of the blind can also be defined. 
+This is a fork of the Blind Card by tungmeister. I needed a option to inverrt the commands.
 
 ![blind card](https://raw.githubusercontent.com/tungmeister/hass-blind-card/master/images/blind-anim.gif)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg?style=for-the-badge)](https://github.com/custom-components/hacs)
 
 This card allows to open, close or set a blind to the position you want. The Color of the blind can also be defined. 
-This is a fork of the Blind Card by tungmeister. I needed a option to inverrt the commands.
+This is a fork of the Blind Card by tungmeister. I needed a option to invert the up/down commands.
 
 ![blind card](https://raw.githubusercontent.com/tungmeister/hass-blind-card/master/images/blind-anim.gif)
 
@@ -25,6 +25,7 @@ This is a fork of the Blind Card by tungmeister. I needed a option to inverrt th
 | buttons_position | string | False | `left` | Set buttons on `left` or on `right` of the blind
 | title_position | string | False | `top` | Set title on `top` or on `bottom` of the blind
 | invert_percentage | boolean | False | `false` | Set it to `true` if your blind is 100% when it is closed, and 0% when it is opened
+| invert_commands | boolean | False | `false` | Set it to true if you want to invert the up/down buttons to match your motors direction
 | blind_color | string | False | 'white' | Set blind Color e.g. `green` or hex `#00FF00`
 
 _Remark : you can also just give the entity ID (without to specify `entity:`) if you don't need to specify the other configurations._

--- a/hass-blind-card.js
+++ b/hass-blind-card.js
@@ -39,8 +39,8 @@ class BlindCard extends HTMLElement {
         }
 
         let invertCommands = false;
-        if (entity && entity.invertCommands) {
-          invertPercentage = entity.invertCommands;
+        if (entity && entity.invert_commands) {
+          invertCommands = entity.invert_commands;
         }
 
         let blindColor = '#ffffff'

--- a/hass-blind-card.js
+++ b/hass-blind-card.js
@@ -38,6 +38,11 @@ class BlindCard extends HTMLElement {
           invertPercentage = entity.invert_percentage;
         }
 
+        let invertCommands = false;
+        if (entity && entity.invertCommands) {
+          invertPercentage = entity.invertCommands;
+        }
+
         let blindColor = '#ffffff'
         if (entity && entity.blind_color) {
           blindColor = entity.blind_color;
@@ -149,11 +154,11 @@ class BlindCard extends HTMLElement {
                 
                 switch (command) {
                   case 'up':
-                      service = 'open_cover';
+                      service = !invertCommands ? 'open_cover' : 'close_cover';
                       break;
                       
                   case 'down':
-                      service = 'close_cover';
+                      service = !invertCommands ? 'close_cover' : 'open_cover';
                       break;
                 
                   case 'stop':


### PR DESCRIPTION
Added option 'invert_commands' to invert the commands when using up/down buttons from card. 
Optional, default false. Can be used in combination with invert_percentage.